### PR TITLE
impl IntoIterator for &Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pub fn main() {
     let document = Document::from(include_str!("stackoverflow.html"));
 
     println!("# Menu");
-    for node in document.find(Attr("id", "hmenus")).find(Name("a")).iter() {
+    for node in &document.find(Attr("id", "hmenus")).find(Name("a")) {
         println!("{} ({:?})", node.text(), node.attr("href").unwrap());
     }
     println!("");

--- a/examples/stackoverflow.rs
+++ b/examples/stackoverflow.rs
@@ -9,7 +9,7 @@ pub fn main() {
     let document = Document::from(include_str!("stackoverflow.html"));
 
     println!("# Menu");
-    for node in document.find(Attr("id", "hmenus")).find(Name("a")).iter() {
+    for node in &document.find(Attr("id", "hmenus")).find(Name("a")) {
         println!("{} ({:?})", node.text(), node.attr("href").unwrap());
     }
     println!("");

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -36,7 +36,7 @@ impl<'a> Selection<'a> {
     pub fn find<P: Predicate>(&self, p: P) -> Selection<'a> {
         let mut bitset = BitSet::new();
 
-        for index in self.bitset.iter() {
+        for index in &self.bitset {
             recur(self.document, &mut bitset, index);
         }
 
@@ -94,7 +94,7 @@ impl<'a> Selection<'a> {
 
     pub fn parents(&self) -> Selection<'a> {
         let mut bitset = BitSet::new();
-        for mut node in self.iter() {
+        for mut node in self {
             while let Some(parent) = node.parent() {
                 bitset.insert(parent.index());
                 node = parent;
@@ -109,7 +109,7 @@ impl<'a> Selection<'a> {
 
     pub fn children(&self) -> Selection<'a> {
         let mut bitset = BitSet::new();
-        for node in self.iter() {
+        for node in self {
             match self.document.nodes[node.index()].data {
                 node::Data::Text(_) => {},
                 node::Data::Element(_, _, ref children) => {
@@ -143,5 +143,14 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Node<'a>> {
         self.inner.next().map(|index| self.selection.document.nth(index).unwrap())
+    }
+}
+
+impl<'a> IntoIterator for &'a Selection<'a> {
+    type Item = Node<'a>;
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }

--- a/tests/node_tests.rs
+++ b/tests/node_tests.rs
@@ -99,7 +99,7 @@ speculate! {
             {
                 use select::predicate::*;
                 let document = Document::from(include_str!("fixtures/struct.Vec.html"));
-                for div in document.find(Name("div")).iter() {
+                for div in &document.find(Name("div")) {
                     assert!(div.is(Name("div")));
                 }
             };

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -33,7 +33,7 @@ speculate! {
 
             let divs = all.filter(Name("div"));
             assert_eq!(divs.iter().count(), 208);
-            for div in divs.iter() {
+            for div in &divs {
                 assert_eq!(div.name(), Some("div"))
             }
 
@@ -41,7 +41,7 @@ speculate! {
 
             let structs = all.filter(Class("struct"));
             assert_eq!(structs.iter().count(), 168);
-            for struct_ in structs.iter() {
+            for struct_ in &structs {
                 assert!(struct_.attr("class").unwrap().contains("struct"))
             };
         }
@@ -54,13 +54,13 @@ speculate! {
 
             let struct_divs = all.find(Class("struct")).find(Name("div"));
             assert_eq!(struct_divs.iter().count(), 204);
-            for struct_div in struct_divs.iter() {
+            for struct_div in &struct_divs {
                 assert_eq!(struct_div.name(), Some("div"));
             };
 
             let struct_as = all.find(Class("struct")).find(Name("a"));
             assert_eq!(struct_as.iter().count(), 1260);
-            for struct_a in struct_as.iter() {
+            for struct_a in &struct_as {
                 assert_eq!(struct_a.name(), Some("a"));
             };
         }
@@ -101,13 +101,13 @@ speculate! {
 
             let div_children = document.find(Name("div")).children();
             assert_eq!(div_children.iter().count(), 1210);
-            for div_child in div_children.iter() {
+            for div_child in &div_children {
                 assert_eq!(div_child.parent().unwrap().name(), Some("div"));
             }
 
             let span_children = document.find(Name("span")).children();
             assert_eq!(span_children.iter().count(), 1986);
-            for span_child in span_children.iter() {
+            for span_child in &span_children {
                 assert_eq!(span_child.parent().unwrap().name(), Some("span"));
             };
         }


### PR DESCRIPTION
This just forwards to `fn iter(&self)`.  It's handy for uses that can
implicitly convert objects to iterators - most notably in the `for`
construct itself.

Many cases that were `for x in selection.iter()` are now converted in
this commit to `for x in &selection` as an example.