### PR TITLE
Implement From<String> for Document

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -115,3 +115,10 @@ impl<'a> From<&'a str> for Document {
         Document::from(StrTendril::from(str))
     }
 }
+
+impl From<String> for Document {
+    /// Parses the given `String` into a `Document`.
+    fn from(string: String) -> Document {
+        Document::from(StrTendril::from(string))
+    }
+}


### PR DESCRIPTION
Currently, one cannot create a Document from a String,
as is the case when reading a response from Hyper into a String.
With From<String>, this is now possible.

Example of new allowed behaviour:
```
let client = hyper::Client::new();
let mut response = try!(client.get(&request_url).send());
let mut body = String::new();
try!(response.read_to_string(&mut body));

let dom = Document::from(body);
```