### PR TITLE
Add .len() method to selection

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -130,6 +130,10 @@ impl<'a> Selection<'a> {
     pub fn first(&self) -> Option<Node<'a>> {
         self.bitset.iter().next().map(|index| self.document.nth(index).unwrap())
     }
+
+    pub fn len(&self) -> usize {
+        self.bitset.len()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
A nice shorthand when doing insane scraping depending on the number of tags matched.