### PR TITLE
Add Selection::last() for symmetry with first()

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -132,6 +132,10 @@ impl<'a> Selection<'a> {
         self.bit_set.iter().next().map(|index| self.document.nth(index).unwrap())
     }
 
+    pub fn last(&self) -> Option<Node<'a>> {
+        self.bit_set.iter().last().map(|index| self.document.nth(index).unwrap())
+    }
+
     pub fn len(&self) -> usize {
         self.bit_set.len()
     }

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -121,6 +121,15 @@ speculate! {
             assert!(document.find(Name("divv")).first().is_none());
         }
 
+        test "Selection::last()" {
+            use select::predicate::*;
+
+            let document = Document::from(include_str!("fixtures/struct.Vec.html"));
+
+            assert!(document.find(Name("div")).last().is_some());
+            assert!(document.find(Name("divv")).last().is_none());
+        }
+
         test "Selection::len() == Selection::iter().count()" {
             use select::predicate::*;
 


### PR DESCRIPTION
Getting the last element leads to some non-trivial lifetime wrangling
when implemented using iterators over a Selection, so adding a last()
method helps avoid those difficulties.

Fixes #17
