### PR TITLE
Separate predicate composition

### DIFF
--- a/examples/stackoverflow.rs
+++ b/examples/stackoverflow.rs
@@ -1,6 +1,6 @@
 extern crate select;
 use select::document::Document;
-use select::predicate::{Predicate, Attr, Class, Name};
+use select::predicate::{Composition, Attr, Class, Name};
 
 pub fn main() {
     // stackoverflow.html was fetched from

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -1,8 +1,23 @@
 use node::{self, Node};
 
 /// A trait implemented by all `Node` matchers.
-pub trait Predicate: Sized {
+pub trait Predicate {
     fn matches(&self, node: &Node) -> bool;
+}
+
+pub trait Composition: Sized {
+    fn or<T: Predicate>(self, other: T) -> Or<Self, T>;
+
+    fn and<T: Predicate>(self, other: T) -> And<Self, T>;
+
+    fn not(self) -> Not<Self>;
+
+    fn child<T: Predicate>(self, other: T) -> Child<Self, T>;
+
+    fn descendant<T: Predicate>(self, other: T) -> Descendant<Self, T>;
+}
+
+impl<P: Predicate> Composition for P {
     fn or<T: Predicate>(self, other: T) -> Or<Self, T> {
         Or(self, other)
     }


### PR DESCRIPTION
This should allow boxing predicates, but requires that the `Composition`
trait be brought into scope where the `Predicate` was previously used
for.

Fixes #35.