### PR TITLE
Updated to html5ever 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/utkarshkukreti/select.rs"
 speculate = "0.0.25"
 
 [dependencies]
-html5ever = "0.15"
+html5ever = "0.18"
 bit-set = "0.4"
 
 [badges]

--- a/src/node.rs
+++ b/src/node.rs
@@ -207,9 +207,9 @@ impl<'a> fmt::Debug for Node<'a> {
     }
 }
 
-impl<'a> serialize::Serializable for Node<'a> {
-    fn serialize<'w, W: io::Write>(&self,
-                                   serializer: &mut serialize::Serializer<'w, W>,
+impl<'a> serialize::Serialize for Node<'a> {
+    fn serialize<S: serialize::Serializer>(&self,
+                                   serializer: &mut S,
                                    traversal_scope: serialize::TraversalScope)
                                    -> io::Result<()> {
         match *self.data() {
@@ -220,7 +220,7 @@ impl<'a> serialize::Serializable for Node<'a> {
                 try!(serializer.start_elem(name.clone(), attrs));
 
                 for child in self.children() {
-                    try!(serialize::Serializable::serialize(&child, serializer, traversal_scope));
+                    try!(serialize::Serialize::serialize(&child, serializer, traversal_scope));
                 }
 
                 try!(serializer.end_elem(name.clone()));


### PR DESCRIPTION
Hi @utkarshkukreti 

We want to show your excellent crate in rust-cookbook https://github.com/brson/rust-cookbook/pull/183 :smile: 
but due to [bug in our documentation test driver](https://github.com/brson/rust-skeptic/issues/18) we need for all of intermediate dependencies to be on the same level.

Long story (really!) made short. We would require to update `select` to latest html5ever released today.

If there is anything wrong with the PR I will gladly fix it!

Best Regards
