### PR TITLE
Add more CSS selectors as predicates.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use std::{fmt, io};
+use std::str::SplitWhitespace;
 
 use html5ever::tendril::StrTendril;
 use html5ever::{serialize, LocalName, QualName};
@@ -93,6 +94,16 @@ impl<'a> Node<'a> {
                 inner: Some(attrs.iter()),
             },
             _ => Attrs { inner: None },
+        }
+    }
+
+    pub fn id(&self) -> Option<&'a str> {
+        self.attr("id")
+    }
+
+    pub fn classes(&self) -> Classes<'a> {
+        Classes {
+            inner: self.attr("class").unwrap_or("").split_whitespace(),
         }
     }
 
@@ -270,6 +281,20 @@ impl<'a> serialize::Serialize for Node<'a> {
             }
             Data::Comment(ref comment) => serializer.write_comment(&comment),
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Classes<'a> {
+    inner: SplitWhitespace<'a>,
+}
+impl<'a> Iterator for Classes<'a> {
+    type Item = &'a str;
+    fn next(&mut self) -> Option<&'a str> {
+        self.inner.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -36,6 +36,8 @@ pub trait Predicate {
 }
 
 /// Matches any Node.
+///
+/// This includes text nodes, comments, and elements. There is no equivalent CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Any;
 
@@ -45,7 +47,21 @@ impl Predicate for Any {
     }
 }
 
-/// Matches Element Node with name `T`.
+/// Matches no Node.
+///
+/// This is roughly equivalent to `:not(*)`.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Nothing;
+
+impl Predicate for Nothing {
+    fn matches(&self, _: &Node) -> bool {
+        false
+    }
+}
+
+/// Matches Element Node with tag name `T`.
+///
+/// This is equivalent to the `tag` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Name<T>(pub T);
 
@@ -56,18 +72,32 @@ impl<'a> Predicate for Name<&'a str> {
 }
 
 /// Matches Element Node containing class `T`.
+///
+/// This is equivalent to the `.class` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Class<T>(pub T);
 
 impl<'a> Predicate for Class<&'a str> {
     fn matches(&self, node: &Node) -> bool {
-        node.attr("class").map_or(false, |classes| {
-            classes.split_whitespace().any(|class| class == self.0)
-        })
+        node.classes().any(|class| class == self.0)
+    }
+}
+
+/// Matches Element Node with ID `T`.
+///
+/// This is equivalent to the `#id` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Id<T>(pub T);
+
+impl<'a> Predicate for Id<&'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.id() == Some(self.0)
     }
 }
 
 /// Matches if the Predicate `T` does not match.
+///
+/// This is equivalent to the `:not(selector)` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Not<T>(pub T);
 
@@ -77,8 +107,9 @@ impl<T: Predicate> Predicate for Not<T> {
     }
 }
 
-/// Matches Element Node containing attribute `N` with value `V` if `V` is an
-/// `&str`, or any value if `V` is `()`.
+/// Matches Element Node containing attribute `N` with value `V`.
+///
+/// This is equivalent to the `[attr=val]` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Attr<N, V>(pub N, pub V);
 
@@ -88,13 +119,95 @@ impl<'a> Predicate for Attr<&'a str, &'a str> {
     }
 }
 
-impl<'a> Predicate for Attr<&'a str, ()> {
+/// Matches Element Node containing attribute `N` which matches function `F`.
+///
+/// There is no equivalent CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrMatches<N, V>(pub N, pub V);
+
+impl<'a, F: Fn(&str) -> bool> Predicate for AttrMatches<&'a str, F> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).map_or(false, &self.1)
+    }
+}
+
+/// Matches Element Node containing attribute `N` which contains pattern `V`.
+///
+/// This is equivalent to the `[attr*=val]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrContains<N, V>(pub N, pub V);
+
+impl<'a> Predicate for AttrContains<&'a str, &'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).map_or(false, |a| a.contains(self.1))
+    }
+}
+
+/// Matches Element Node containing attribute `N` which starts with pattern `V`.
+///
+/// This is equivalent to the `[attr^=val]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrStartsWith<N, V>(pub N, pub V);
+
+impl<'a> Predicate for AttrStartsWith<&'a str, &'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).map_or(false, |a| a.starts_with(self.1))
+    }
+}
+
+/// Matches Element Node containing attribute `N` which ends with pattern `V`.
+///
+/// This is equivalent to the `[attr$=val]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrEndsWith<N, V>(pub N, pub V);
+
+impl<'a> Predicate for AttrEndsWith<&'a str, &'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).map_or(false, |a| a.ends_with(self.1))
+    }
+}
+
+/// Matches Element Node containing attribute `N` contains the word `V` surrounded by either the
+/// edges of the string, or whitespace.
+///
+/// This is equivalent to the `[attr~=val]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrContainsWord<N, V>(pub N, pub V);
+
+impl<'a> Predicate for AttrContainsWord<&'a str, &'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).map_or(false, |a| a.split_whitespace().any(|w| w == self.1))
+    }
+}
+
+/// Matches Element Node containing attribute `N` being either exactly the value `V` or `V`
+/// followed by `"-"`, then some string.
+///
+/// This is equivalent to the `[attr|=val]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AttrLang<N, V>(pub N, pub V);
+
+impl<'a> Predicate for AttrLang<&'a str, &'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        node.attr(self.0).and_then(|a| a.split('-').next()).map_or(false, |a| a == self.1)
+    }
+}
+
+/// Matches Element Node containing attribute `N`.
+///
+/// This is equivalent to the `[attr]` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct HasAttr<N>(pub N);
+
+impl<'a> Predicate for HasAttr<&'a str> {
     fn matches(&self, node: &Node) -> bool {
         node.attr(self.0).is_some()
     }
 }
 
 /// Matches if the function returns true.
+///
+/// There is no equivalent CSS selector.
 impl<F: Fn(&Node) -> bool> Predicate for F {
     fn matches(&self, node: &Node) -> bool {
         self(node)
@@ -102,6 +215,8 @@ impl<F: Fn(&Node) -> bool> Predicate for F {
 }
 
 /// Matches any Element Node.
+///
+/// This is equivalent to the `*` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Element;
 
@@ -115,6 +230,8 @@ impl Predicate for Element {
 }
 
 /// Matches any Text Node.
+///
+/// There is no equivalent CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Text;
 
@@ -128,6 +245,8 @@ impl Predicate for Text {
 }
 
 /// Matches any Comment Node.
+///
+/// There is no equivalent CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Comment;
 
@@ -141,6 +260,8 @@ impl Predicate for Comment {
 }
 
 /// Matches if either inner Predicate `A` or `B` matches the Node.
+///
+/// This is equivalent to the `a, b` selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Or<A, B>(pub A, pub B);
 
@@ -151,6 +272,8 @@ impl<A: Predicate, B: Predicate> Predicate for Or<A, B> {
 }
 
 /// Matches if the inner Predicate `A` and `B` both match the Node.
+///
+/// This is equivalent to combining CSS selectors, usually by concatenating, e.g. `tag.class`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct And<A, B>(pub A, pub B);
 
@@ -162,21 +285,21 @@ impl<A: Predicate, B: Predicate> Predicate for And<A, B> {
 
 /// Matches if inner Predicate `B` matches the node and `A` matches the parent
 /// of the node.
+///
+/// This is equivalent to the `parent > child` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Child<A, B>(pub A, pub B);
 
 impl<A: Predicate, B: Predicate> Predicate for Child<A, B> {
     fn matches(&self, node: &Node) -> bool {
-        if let Some(parent) = node.parent() {
-            self.1.matches(node) && self.0.matches(&parent)
-        } else {
-            false
-        }
+        self.1.matches(node) && node.parent().map_or(false, |parent| self.0.matches(&parent))
     }
 }
 
 /// Matches if inner Predicate `B` matches the node and `A` matches any of the
 /// parents of node.
+///
+/// This is equivalent to the `parent descendant` CSS selector.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Descendant<A, B>(pub A, pub B);
 
@@ -191,6 +314,63 @@ impl<A: Predicate, B: Predicate> Predicate for Descendant<A, B> {
                 node = parent;
             }
         }
-        return false;
+        false
+    }
+}
+
+/// Matches if inner Predicate `B` matches the node and `A` matches the node before this one.
+///
+/// This is equivalent to the `before + after` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ImmediatelyAfter<A, B>(pub A, pub B);
+
+impl<A: Predicate, B: Predicate> Predicate for ImmediatelyAfter<A, B> {
+    fn matches(&self, node: &Node) -> bool {
+        self.1.matches(node) && node.prev().map_or(false, |prev| self.0.matches(&prev))
+    }
+}
+
+/// Matches if inner Predicate `B` matches the node and `A` matches any node before this one.
+///
+/// This is equivalent to the `before ~ after` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct After<A, B>(pub A, pub B);
+
+impl<A: Predicate, B: Predicate> Predicate for After<A, B> {
+    fn matches(&self, node: &Node) -> bool {
+        if self.1.matches(node) {
+            let mut node = *node;
+            while let Some(prev) = node.prev() {
+                if self.0.matches(&prev) {
+                    return true;
+                }
+                node = prev;
+            }
+        }
+        false
+    }
+}
+
+/// Matches a node which has no children, except comments.
+///
+/// This is equivalent to the `:empty` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Empty;
+
+impl Predicate for Empty {
+    fn matches(&self, node: &Node) -> bool {
+        node.children().all(|n| n.as_comment().is_none())
+    }
+}
+
+/// Matches the root node of the document.
+///
+/// This is equivalent to the `:root` CSS selector.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Root;
+
+impl Predicate for Root {
+    fn matches(&self, node: &Node) -> bool {
+        node.parent().is_none()
     }
 }

--- a/tests/predicate_tests.rs
+++ b/tests/predicate_tests.rs
@@ -66,8 +66,11 @@ speculate! {
         test "Attr()" {
             assert_eq!(Attr("id", "post-0").matches(&html), false);
             assert_eq!(Attr("id", "post-0").matches(&article), true);
-            assert_eq!(Attr("id", ()).matches(&html), false);
-            assert_eq!(Attr("id", ()).matches(&article), true);
+        }
+
+        test "HasAttr()" {
+            assert_eq!(HasAttr("id").matches(&html), false);
+            assert_eq!(HasAttr("id").matches(&article), true);
         }
 
         test "Fn(&Node) -> bool" {


### PR DESCRIPTION
Implements #40.

Changes:

* Adds `Node::classes` which returns an iterator, and `Node::id` for convenience.
* Documents which CSS selectors are equivalent to which predicates.
* Renames `Attr(s, ())` to `HasAttr` (breaking change; can be removed if desired).
* Adds `Nothing` predicate, the opposite of `Any`.
* Adds `Id` predicate, which calls `Node::id`.
* Adds `Root` predicate, that ensures that the node has no parents.
* Adds `Empty` predicate, which allows comment children to be compatible with CSS.
* Adds `AttrMatches` predicate for convenience; it takes a string for an attribute and a function to test the string.
* Adds `AttrContains`, `AttrStartsWith`, and `AttrEndsWith` which call the relevant string functions.
* Adds `AttrContainsWord` and `AttrLang`, which are kind of esoteric but are equivalent to the `[attr~=word]` and `[attr|=lang]` selectors.

Once all of the CSS selectors are added we can potentially allow parsing `&str -> Box<Predicate>`.