### PR TITLE
chore(dependency): bump html5ever to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/utkarshkukreti/select.rs"
 speculate = "0.0.25"
 
 [dependencies]
-html5ever = "0.18"
+html5ever = "0.22"
 bit-set = "0.4"
 
 [badges]

--- a/src/node.rs
+++ b/src/node.rs
@@ -259,7 +259,7 @@ impl<'a> serialize::Serialize for Node<'a> {
                     try!(serialize::Serialize::serialize(
                         &child,
                         serializer,
-                        traversal_scope
+                        traversal_scope.clone()
                     ));
                 }
 


### PR DESCRIPTION
`html5ever::serialize::TraversalScope` is no longer `Copy` since 0.19.

Cloning should be cheap because this only increments atomic refcounts of `Atom`s used in `markup5ever::interface::QualName` if `TraversalScope::ChildrenOnly` variant is used.