### PR TITLE
Upgraded test framework to version compatible with latest nightlies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/utkarshkukreti/select.rs"
 repository = "https://github.com/utkarshkukreti/select.rs"
 
 [dev-dependencies]
-speculate = "0.0.25"
+speculate = "0.0.26"
 
 [dependencies]
 html5ever = "0.22"

--- a/examples/stackoverflow-text-only.rs
+++ b/examples/stackoverflow-text-only.rs
@@ -1,0 +1,42 @@
+extern crate select;
+
+use select::document::Document;
+use select::node::{Node, Data};
+
+///
+/// Just the text of a web page without tags or scripts.
+///
+/// The document.nth(i) lists all the nodes in order with the root node being the first.
+///
+/// To be able to skip a node's contents one needs to recurse down through the root node's children.
+pub fn main() {
+    // stackoverflow.html was fetched from
+    // http://stackoverflow.com/questions/tagged/rust?sort=votes&pageSize=50 on
+    // Aug 10, 2015.
+    let document = Document::from(include_str!("stackoverflow.html"));
+
+    let root_node = document.nth(0).unwrap();
+
+    let mut buffer = String::new();
+    build_text(&mut buffer, &root_node);
+    println!("{}", buffer);
+}
+
+fn build_text(buffer: &mut String, node: &Node) {
+    for child in node.children() {
+        match *child.data() {
+            Data::Element(ref name, _) => {
+                let tag_name : &str = &name.local.to_string();
+                match tag_name {
+                    "script" | "noscript" | "noscript-warning" => {},
+                    _ => { build_text(buffer, &child); }
+                }
+            },
+            Data::Text(ref text) => {
+                buffer.push_str(&text.to_string());
+                build_text(buffer, &child);
+            },
+            _ => { build_text(buffer, &child); }
+        }
+    }
+}


### PR DESCRIPTION
Added example of how to just get the plain text from a webpage.
(E.g. for machine learning sometimes you just want access to plain text).

If there's a neater way to do it, I'd love to see it - I couldn't find a specific root node function on document? Did I miss one, if not it would be nice to call it out as a specific function rather than nth(0).