### PR TITLE
Add support for text matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "select"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Utkarsh Kukreti <utkarshkukreti@gmail.com>"]
 description = "A library to extract useful data from HTML documents, suitable for web scraping."
 license = "MIT"

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -116,9 +116,19 @@ impl Predicate for Element {
 
 /// Matches any Text Node.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Text;
+pub struct Text<T>(pub T);
 
-impl Predicate for Text {
+impl<'a> Predicate for Text<&'a str> {
+    fn matches(&self, node: &Node) -> bool {
+        match *node.data() {
+            node::Data::Text(ref text) => &**text == self.0,
+            _ => false,
+        }
+    }
+}
+
+
+impl Predicate for Text<()> {
     fn matches(&self, node: &Node) -> bool {
         match *node.data() {
             node::Data::Text(..) => true,

--- a/tests/predicate_tests.rs
+++ b/tests/predicate_tests.rs
@@ -85,13 +85,15 @@ speculate! {
             assert_eq!(super::Element.matches(&foo), false);
         }
 
-        test "Text" {
-            assert_eq!(super::Text.matches(&html), false);
-            assert_eq!(super::Text.matches(&head), false);
-            assert_eq!(super::Text.matches(&body), false);
-            assert_eq!(super::Text.matches(&article), false);
-            assert_eq!(super::Text.matches(&foo), true);
-            assert_eq!(super::Text.matches(&comment), false);
+        test "Text()" {
+            assert_eq!(super::Text(()).matches(&html), false);
+            assert_eq!(super::Text(()).matches(&head), false);
+            assert_eq!(super::Text(()).matches(&body), false);
+            assert_eq!(super::Text(()).matches(&article), false);
+            assert_eq!(super::Text(()).matches(&foo), true);
+            assert_eq!(super::Text(()).matches(&comment), false);
+            assert_eq!(super::Text("foo").matches(&foo), true);
+            assert_eq!(super::Text("bar").matches(&foo), false);
         }
 
         test "Comment" {


### PR DESCRIPTION
This PR adds support for matching text.

### Usecase
Find the correct table to iteratore over cells on websites without attributes.

e.g. 

```
<html><body>
<table><tr><td>First Table<td><tr><tr><td>..</td></tr></table>
<table><tr><td>Second Table<td><tr><tr><td>important cell</td></tr></table>
...
</body></html>
```

Before you would need to rely on the nth table child of body but that breaks if the order changes.