### PR TITLE
Update the html5ever dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ speculate = "0.1.2"
 [dependencies]
 html5ever = "0.25"
 bit-set = "0.5"
+markup5ever_rcdom = "0.1"
 
 [badges]
 travis-ci = { repository = "utkarshkukreti/select.rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/utkarshkukreti/select.rs"
 speculate = "0.1.2"
 
 [dependencies]
-html5ever = "0.23"
+html5ever = "0.25"
 bit-set = "0.5"
 
 [badges]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -4,6 +4,8 @@ extern crate test;
 
 extern crate html5ever;
 
+extern crate markup5ever_rcdom;
+
 extern crate select;
 
 pub use select::document::Document;
@@ -18,12 +20,13 @@ speculate! {
             let str = include_str!("../tests/fixtures/struct.Vec.html");
         }
 
-        bench "constructing html5ever::rcdom::RcDom" |b| {{
-            use html5ever::{parse_document, rcdom};
+        bench "constructing markup5ever_rcdom::RcDom" |b| {{
+            use html5ever::parse_document;
+            use markup5ever_rcdom::RcDom;
             use html5ever::tendril::stream::TendrilSink;
 
             b.iter(|| {
-                let rc_dom = parse_document(rcdom::RcDom::default(),
+                let rc_dom = parse_document(RcDom::default(),
                                             Default::default()).one(str);
                 rc_dom
             });

--- a/src/document.rs
+++ b/src/document.rs
@@ -46,37 +46,38 @@ impl From<StrTendril> for Document {
     /// Parses the given `StrTendril` into a `Document`.
     fn from(tendril: StrTendril) -> Document {
         use html5ever::tendril::stream::TendrilSink;
-        use html5ever::{parse_document, rcdom};
+        use html5ever::parse_document;
+        use markup5ever_rcdom::{RcDom, NodeData, Handle};
 
         let mut document = Document { nodes: vec![] };
 
-        let rc_dom = parse_document(rcdom::RcDom::default(), Default::default()).one(tendril);
+        let rc_dom = parse_document(RcDom::default(), Default::default()).one(tendril);
         recur(&mut document, &rc_dom.document, None, None);
         return document;
 
         fn recur(
             document: &mut Document,
-            node: &rcdom::Handle,
+            node: &Handle,
             parent: Option<usize>,
             prev: Option<usize>,
         ) -> Option<usize> {
             match node.data {
-                rcdom::NodeData::Document => {
+                NodeData::Document => {
                     let mut prev = None;
                     for child in node.children.borrow().iter() {
                         prev = recur(document, &child, None, prev)
                     }
                     None
                 }
-                rcdom::NodeData::Text { ref contents } => {
+                NodeData::Text { ref contents } => {
                     let data = node::Data::Text(contents.borrow().clone());
                     Some(append(document, data, parent, prev))
                 }
-                rcdom::NodeData::Comment { ref contents } => {
+                NodeData::Comment { ref contents } => {
                     let data = node::Data::Comment(contents.clone());
                     Some(append(document, data, parent, prev))
                 }
-                rcdom::NodeData::Element {
+                NodeData::Element {
                     ref name,
                     ref attrs,
                     ..

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate bit_set;
 extern crate html5ever;
+extern crate markup5ever_rcdom;
 
 pub mod document;
 pub mod node;


### PR DESCRIPTION
This requires using the newly split-off RcDom implementation from html5ever.

Since this is now clearly marked that it shouldn't be used in production, this raises the question, should a production-ready DOM implementation be used instead for select.rs?