### PR TITLE
Implement `Debug` for `Find`

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -329,6 +329,16 @@ pub struct Find<'a, P: Predicate> {
     predicate: P,
 }
 
+impl<'a, P: Predicate> std::fmt::Debug for Find<'a, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Find")
+            .field("document", &self.document)
+            .field("descendants", &self.descendants)
+            // predicate may be closure not implementing Debug
+            .finish()
+    }
+}
+
 impl<'a, P: Predicate> Find<'a, P> {
     pub fn into_selection(self) -> Selection<'a> {
         Selection::new(self.document, self.map(|node| node.index()).collect())


### PR DESCRIPTION
As mentioned in https://github.com/utkarshkukreti/select.rs/issues/61, I find myself in need of a `Debug` implementation for `Find`.

The only member of `Find` that does not necessarily implement `Debug` is `predicate` (which may be a closure), so I left it out from the `Debug` impl. This is in line with Rust's `Filter` (and other iterators).