### PR TITLE
Updated Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/utkarshkukreti/select.rs"
 
 [dependencies]
 bit-set = "0.5"
-html5ever = "0.25"
-markup5ever_rcdom = "0.1"
+html5ever = "0.26"
+markup5ever_rcdom = "0.2"
 
 [dev-dependencies]
 speculate = "0.1.2"


### PR DESCRIPTION
Updated Cargo.toml dep versions.

Passes `cargo audit`, `cargo outdated -wR`, `cargo +nightly udeps`