### PR TITLE
Exclude benches, tests, fixtures, and examples from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ license = "MIT"
 documentation = "https://docs.rs/select"
 homepage = "https://github.com/utkarshkukreti/select.rs"
 repository = "https://github.com/utkarshkukreti/select.rs"
+exclude = [
+    "/benches/",
+    "/examples/",
+    "/tests/",
+    "/.github/",
+]
 
 [dependencies]
 bit-set = "0.5"


### PR DESCRIPTION
We were looking into packaging this crate for Fedora Linux as a dependency of [mdBook](https://github.com/rust-lang/mdBook). During review, it was noticed that the crate sources include some rather large test input files, which also don't look like they are a) reflected in the crate license or b) free from copyright issues.

This PR ensures that example code (including the StackOverflow HTML page), tests (including the std docs HTML page), benchmarks (not useful in published crates), and GitHub Actions workflows are excluded from the files that are included when publishing to crates.io.

This also makes the published .crate files a lot smaller for downloading from crates.io (about ~80% size reduction).

If this change is acceptable, then it would be great if you could publish v0.6.1 to crates.io afterwards for this (and the LICENSE file that was included after the 0.6.0 release) to take effect.
